### PR TITLE
Delete simon-marlow.public

### DIFF
--- a/root-keys/simon-marlow.public
+++ b/root-keys/simon-marlow.public
@@ -1,1 +1,0 @@
-{"keytype":"ed25519","keyval":{"public":"iw8qPJEK17idtJfJpgPDzthzzq+O5XlNfMaK7750AOA="}}


### PR DESCRIPTION
@simonmar expressed to me in an email conversation that he no longer has this key, and hasn't participated in the signing process for some time.
