### PR TITLE
Move Simon Marlow's root key out of the set of active keys

### DIFF
--- a/root-keys/obsolete/simon-marlow.public
+++ b/root-keys/obsolete/simon-marlow.public
@@ -1,0 +1,1 @@
+{"keytype":"ed25519","keyval":{"public":"iw8qPJEK17idtJfJpgPDzthzzq+O5XlNfMaK7750AOA="}}

--- a/root-keys/simon-marlow.public
+++ b/root-keys/simon-marlow.public
@@ -1,1 +1,0 @@
-{"keytype":"ed25519","keyval":{"public":"iw8qPJEK17idtJfJpgPDzthzzq+O5XlNfMaK7750AOA="}}


### PR DESCRIPTION
Based on email correspondence, he doesn't have the private key and hasn't participated in this process for a long time.

Supersedes #7 