### PR TITLE
Remove mistaken signature from root.json

### DIFF
--- a/root.json
+++ b/root.json
@@ -3,7 +3,6 @@
     {"keyid":"1ea9ba32c526d1cc91ab5e5bd364ec5e9e8cb67179a471872f6e26f0ae773d42","method":"ed25519","sig":"cLDTEvwOxB23Lblq9vZWXm6vogFdX7oV6Agce+3lf/XJOHy3V8bR57o0uCig8X/EO4DLaEigeiT90BlT6p+3Aw=="},
     {"keyid":"0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d","method":"ed25519","sig":"M2JjxSB3K63LJorHwI6W1IXP77xeY7fHxEUgCdcvsEfLJXWEx0kJR8lo5nXxH3hj3UznS7ipjPk2DbIv4BpzDA=="},
     {"keyid":"d26e46f3b631aae1433b89379a6c68bd417eb5d1c408f0643dcc07757fece522","method":"ed25519","sig":"zuOH4xWxOd/6/wECdmisRrwuCyAKVRkiRaWHYHu24gRg4gztvtMlK9tQe29zFG7dz9PDCSpUkRL3XMbxpNuoAw=="},
-    {"keyid":"b0107b7b3ccbda342459fc9ef98e6ea9bec672a5046bd310ea70915a91d846a7","method":"ed25519","sig":"nlmc1qQow+UhFdpQaraUgxHfATpccV2il1fhNS5sr1V7FtI04bRGmj3h5KU36mFP0Jqa5Ru97iZVGytWvaveBA=="},
     {"keyid":"fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0","method":"ed25519","sig":"diurPS5TgPMtAnWSEw7FSxIHTfyt+JdA+Cafo+/+ne73nGpXtiVxcbTfyVhxnyEU3DJmNlzIyNagL4k1bN1IAA=="},
     {"keyid":"be75553f3c7ba1dbe298da81f1d1b05c9d39dd8ed2616c9bddf1525ca8c03e48","method":"ed25519","sig":"rG7/Qc2LAvvlt81URfKLnvQCMddUNXOw0U0L+gBL9x3ZM1QeylqsQoKa+nD+ric8gaSEnGfAddOS48T1WNv5AA=="}
   ],


### PR DESCRIPTION
It seems that one signature was performed with the wrong key. This is causing clients to fail to verify, even though there are sufficient correct signatures to satisfy the requirements.

This PR removes the offending signature, which should allow clients to connect again.