### PR TITLE
Simple script to check that root.json parses correctly

### DIFF
--- a/scripts/check-root-json.hs
+++ b/scripts/check-root-json.hs
@@ -1,0 +1,55 @@
+{- cabal:
+build-depends: base ^>= 4.17.1.0
+             , bytestring
+             , base16-bytestring ^>= 1.0
+             , containers
+             , ed25519
+             , hackage-security ^>= 0.6.2.3
+-}
+{- project:
+with-compiler: ghc-9.4.5
+-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+import Control.Monad
+import Crypto.Sign.Ed25519 (unPublicKey)
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Char8 qualified as BS
+import Data.Foldable (for_)
+import Data.Map qualified as Map
+import Hackage.Security.Key.Env qualified as KeyEnv
+import Hackage.Security.Server
+import Hackage.Security.Util.Path (fromFilePath, makeAbsolute, toFilePath)
+import Hackage.Security.Util.Pretty (pretty)
+import Hackage.Security.Util.Some
+import System.Environment (getArgs)
+import System.Exit (exitFailure, exitSuccess)
+
+main = do
+  getArgs
+    >>= traverse
+      ( \fp -> do
+          afp <- makeAbsolute (fromFilePath fp)
+          readJSON_Keys_NoLayout KeyEnv.empty afp >>= \case
+            Left e ->
+              do
+                putStrLn $ "Deserialisation error in " ++ fp
+                putStrLn $ pretty e
+                exitFailure
+            Right (sr :: Signed Root) ->
+              do
+                putStrLn $ fp ++ " seems to work"
+                for_ (Map.toList $ KeyEnv.keyEnvMap $ rootKeys $ signed sr) $ \(KeyId keyId, somePublicKey) ->
+                  putStrLn $ "keyId: " ++ keyId ++ "\tpublic key: " ++ showSomePublicKey somePublicKey
+      )
+
+showSomePublicKey :: Some PublicKey -> [Char]
+showSomePublicKey = BS.unpack . Base16.encode . exportSomePublicKey
+  where
+    exportSomePublicKey :: Some PublicKey -> BS.ByteString
+    exportSomePublicKey (Some k) = exportPublicKey k
+
+    exportPublicKey :: PublicKey a -> BS.ByteString
+    exportPublicKey (PublicKeyEd25519 pub) = unPublicKey pub


### PR DESCRIPTION
This simple script uses hackage-security to parse the root.json file.
Adding this as an automated test should prevent issues like today's.

Example usage:

```
❯ cabal run -- scripts/check-root-json.hs ~/root.json
Deserialisation error in /home/andrea/root.json
Unknown key: b0107b7b3ccbda342459fc9ef98e6ea9bec672a5046bd310ea70915a91d846a7
```

```
❯ cabal run -- scripts/check-root-json.hs ~/root2.json
/home/andrea/root2.json seems to work
keyId: 0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d	public key: cdace6e70e3cd2bfb33cee99d3ef1f8c6bb166d6fda40ba856643e564b82be05
keyId: 1ea9ba32c526d1cc91ab5e5bd364ec5e9e8cb67179a471872f6e26f0ae773d42	public key: 6d8a145d743d4ed5f5d14ae268c890b5371cb973c69e695d3faf1d8f367b70ba
keyId: 280b10153a522681163658cb49f632cde3f38d768b736ddbc901d99a1a772833	public key: 687409eee951ca398a380af4d79d1da77f6be4abc5f9f7702495d37552d1403c
keyId: 2a96b1889dc221c17296fcc2bb34b908ca9734376f0f361660200935916ef201	public key: 2234e8c89969fd9d9f5e4664e8449ea8755a1711627508849682ea7c081c1de0
keyId: 51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921	public key: 648f1d8b76bd527d2cd9106bb791b0551bdf39756ecb00037d718f65f9220dbd
keyId: 772e9f4c7db33d251d5c6e357199c819e569d130857dc225549b40845ff0890d	public key: 3357ad11cb1d6f46b45e8b7ec1a4fd9bb68dc7f48c6213cf62f1c3e14bc419ff
keyId: aa315286e6ad281ad61182235533c41e806e5a787e0b6d1e7eef3f09d137d2e9	public key: 781c7443c9f6253b707eb907f64515649045909ebc838a13665f22d555c92d67
keyId: ae2c941863a3219fb3a12579a020642b912ab39b4ff3d1cc20ad317afd0d94c5	public key: 9bfcbaa869554e61bd8b9d617f3e5e6e17a73fcdaf33aa18a24910b23f0f731e
keyId: be75553f3c7ba1dbe298da81f1d1b05c9d39dd8ed2616c9bddf1525ca8c03e48	public key: c9d3759c6190efd2b54349cdfae97e2e7f0cc6291307de70d18746777bf79268
keyId: d26e46f3b631aae1433b89379a6c68bd417eb5d1c408f0643dcc07757fece522	public key: e62520c2a6425ab08992da8cc746c1308ba82324f80354581a8cf372144df6b0
keyId: fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0	public key: b913dd4a22f7fcc36c939d33e8d079e40068d0eaeb3435e282d0ae978bedce6c
```
