### PR TITLE
The 2026 root key signing ceremony

### DIFF
--- a/root.json
+++ b/root.json
@@ -1,13 +1,12 @@
-
+{
   "signatures": [
-    {"keyid":"d26e46f3b631aae1433b89379a6c68bd417eb5d1c408f0643dcc07757fece522","method":"ed25519","sig":"NHq3YXY+quGYC0FFR/8CJNEXxAw1ZdUZv1U+jaDb6yE7McPjbJhSjZzyd5HNZD3VtO/jpMEaki3VmYNTjiu7Bw=="},
-    {"keyid":"0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d","method":"ed25519","sig":"tVORBg4g11IxafkaUkqYgcHAsHm07eK4gQ26ohkHIm1wwb9pqLWpKRGM3x6974B9IcJw+gNt8Yo1w0KOWcJRAQ=="},
-    {"keyid":"fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0","method":"ed25519","sig":"mqiJgl+FHtZVLImsIWvsK/XyrVM4V33WxSRlj/grYmMkfjc0MfkBJ42pvylQ5ZijpZGHWLZachTADH3rZUEqAg=="},
-    {"keyid":"1ea9ba32c526d1cc91ab5e5bd364ec5e9e8cb67179a471872f6e26f0ae773d42","method":"ed25519","sig":"xPm0+iB/3PQ34MbSbJ1yqY7QCs/O2OY5d42t7PJyWgx59KsCTnxtOwUgMQDALnNiuPTJmfRItSNwNVHXe4uhCQ=="}
+ {"keyid":"fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0","method":"ed25519","sig":"oVKwSVE8nsRHItJefPii6G9pEIBDnHhaPYyDGZZOIvzd4Ng487AtMrBVV77c+pAKHahNdkRwJydjtthjl7CGCA=="},
+ {"keyid":"c7de58fc6a224b92b5b513f26fbb8b370f2d97c7cfe0075a951314a55734be93","method":"ed25519","sig":"j52o4QNmoYJOwU5vKJgEf04beZzl0oBcGkG0ngTPQqWW8aic+UjoLMEjeiTMfLEVSbFvgqWwNSM4TiNj9jGrBQ=="},
+ {"keyid":"d26e46f3b631aae1433b89379a6c68bd417eb5d1c408f0643dcc07757fece522","method":"ed25519","sig":"iduzng6FKI/NkSk36oxKbvwCK/zuHMKx+GU+CWfyEGz+YbrXj8ZApvF6tCk9MX00Ep8+0LzeCCRcoiQ5dRtiBQ=="}
   ],
   "signed": {
     "_type": "Root",
-    "expires": "2026-07-31T23:59:59Z",
+    "expires": "2027-07-31T23:59:59Z",
     "keys": {
       "0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d": {
         "keytype": "ed25519",
@@ -114,6 +113,6 @@
         "threshold": 1
       }
     },
-    "version": 7
+    "version": 8
   }
 }


### PR DESCRIPTION
The following changes were made to root.json:

* Version was bumped from 7 to 8
* Expiration was set to 2027-07-31T23:59:59Z
* Three signers certified these changes:

  - Adam (fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0)
  - Tikhon (c7de58fc6a224b92b5b513f26fbb8b370f2d97c7cfe0075a951314a55734be93)
  - Joachim (d26e46f3b631aae1433b89379a6c68bd417eb5d1c408f0643dcc07757fece522)

This meets the threshold of 3